### PR TITLE
Bump `pylint` version to `2.17.7`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: image
+
+IMAGE_NAME ?= codeclimate/codeclimate-pylint
+
+image:
+	docker build --rm -t $(IMAGE_NAME) .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pylint==2.15.3
+pylint==2.17.7
 pylint-django==2.5.3
 django==3.2.15
 pylint-celery==0.3


### PR DESCRIPTION
This bumps `pylint` to the last minor version before `3.0.0` and adds a `Makefile` for more easily building the image.

Note: forked this repository to `codeclimate-community` since the original owner archived `codeclimate-pylint` last month.